### PR TITLE
fix munin agent (#148)

### DIFF
--- a/agent-local/munin
+++ b/agent-local/munin
@@ -1,6 +1,6 @@
 # Lokale Einzelchecks
 export MUNIN_LIBDIR=/usr/share/munin
-if cd munin-scripts
+if cd $MUNIN_LIBDIR/munin-scripts
 then
   for skript in $(ls)
   do


### PR DESCRIPTION
Without the full munin-scripts path, this script won't find munin file and return nothing.